### PR TITLE
bug: 41 bug make basic setupgeneralrcsh exit gracefully

### DIFF
--- a/alias/basic-setup.generalrc.sh
+++ b/alias/basic-setup.generalrc.sh
@@ -9,7 +9,7 @@ shared_scripts_path="../shared-scripts"
 if [ ! -d "$shared_scripts_path" ]; then
 		echo -e "error finding shared-scripts..." >&2
 		echo -e "exiting gracefully without initializing basic-setup..." >&2
-		exit 0
+		return
 fi
 
 # Include the shared-scripts/bin in the PATH
@@ -56,7 +56,7 @@ esac
 } || {
 	echo "error getting source and dir..." >&2
 	echo "exiting gracefully without initializing basic-setup..." >&2
-	exit 0
+	return
 }
 source="$(echo "$sd" | jq -r .source)"
 dir="$(echo "$sd" | jq -r .dir)"
@@ -69,7 +69,7 @@ if [ -d "$dir/sh/" ]; then
 		} || {
 			echo "error sourcing $dir/sh/$basic_setup_generalrc_sh_f" >&2
 			echo "exiting gracefully without initializing the rest of basic-setup..." >&2
-			exit 0
+			return
 		}
 	done
 fi
@@ -80,7 +80,7 @@ if [ -d "$dir/$extra_folder/" ]; then
 		} || {
 			echo "error sourcing $dir/$extra_folder/$basic_setup_generalrc_sh_f" >&2
 			echo "exiting gracefully without initializing the rest of basic-setup..." >&2
-			exit 0
+			return
 		}
 	done
 fi
@@ -94,5 +94,5 @@ export BASIC_SETUP_GENERAL_RC_HAS_RUN=true
 } || {
 	echo "error setting MANPAGER..." >&2
 	echo "exiting gracefully without initializing the rest of basic-setup..." >&2
-	exit 0
+	return
 }

--- a/alias/basic-setup.generalrc.sh
+++ b/alias/basic-setup.generalrc.sh
@@ -8,8 +8,8 @@ shared_scripts_path="../shared-scripts"
 [ ! -d "$shared_scripts_path" ] && shared_scripts_path=$(find / -type d -wholename "*basic-setup/shared-scripts")
 if [ ! -d "$shared_scripts_path" ]; then
 		echo -e "error finding shared-scripts..." >&2
-		# TODO: https://github.com/mrlunchbox777/basic-setup/issues/41
-		exit 1
+		echo -e "exiting gracefully without initializing basic-setup..." >&2
+		exit 0
 fi
 
 # Include the shared-scripts/bin in the PATH

--- a/alias/basic-setup.generalrc.sh
+++ b/alias/basic-setup.generalrc.sh
@@ -26,7 +26,11 @@ fi
 source=""
 
 . "$shared_scripts_path/bin/general-identify-shell-function"
-export CURRENT_SHELL="$(identify-shell-function | sed -r 's/[\ -]//g' )"
+{
+	export CURRENT_SHELL="$(identify-shell-function | sed -r 's/[\ -]//g' )"
+} || {
+	export CURRENT_SHELL="sh"
+}
 echo "shell - $CURRENT_SHELL"
 
 case "$CURRENT_SHELL" in
@@ -47,24 +51,48 @@ case "$CURRENT_SHELL" in
 		;;
 esac
 
-sd="$(general-get-source-and-dir -s "$source")"
+{
+	sd="$(general-get-source-and-dir -s "$source")"
+} || {
+	echo "error getting source and dir..." >&2
+	echo "exiting gracefully without initializing basic-setup..." >&2
+	exit 0
+}
 source="$(echo "$sd" | jq -r .source)"
 dir="$(echo "$sd" | jq -r .dir)"
 export BASIC_SETUP_GENERAL_RC_DIR="$dir"
 
 if [ -d "$dir/sh/" ]; then
 	for basic_setup_generalrc_sh_f in $(ls -p $dir/sh/ | grep -v /); do
-		. $dir/sh/$basic_setup_generalrc_sh_f
+		{
+			. $dir/sh/$basic_setup_generalrc_sh_f
+		} || {
+			echo "error sourcing $dir/sh/$basic_setup_generalrc_sh_f" >&2
+			echo "exiting gracefully without initializing the rest of basic-setup..." >&2
+			exit 0
+		}
 	done
 fi
 if [ -d "$dir/$extra_folder/" ]; then
 	for basic_setup_generalrc_sh_f in $(ls -p $dir/$extra_folder/ | grep -v /); do
-		. $dir/$extra_folder/$basic_setup_generalrc_sh_f
+		{
+			. $dir/$extra_folder/$basic_setup_generalrc_sh_f
+		} || {
+			echo "error sourcing $dir/$extra_folder/$basic_setup_generalrc_sh_f" >&2
+			echo "exiting gracefully without initializing the rest of basic-setup..." >&2
+			exit 0
+		}
 	done
 fi
 
 export BASIC_SETUP_GENERAL_RC_DIR="$dir"
 export BASIC_SETUP_GENERAL_RC_HAS_RUN=true
-if [[ "$(general-command-installed -c bat)" == "true" ]]; then
-	export MANPAGER="sh -c 'col -bx | bat -l man -p'"
-fi
+{
+	if [[ "$(general-command-installed -c bat)" == "true" ]]; then
+		export MANPAGER="sh -c 'col -bx | bat -l man -p'"
+	fi
+} || {
+	echo "error setting MANPAGER..." >&2
+	echo "exiting gracefully without initializing the rest of basic-setup..." >&2
+	exit 0
+}


### PR DESCRIPTION
Thanks for contributing!

## Background

To pass the semanic-prs check, ensure you prefix your title with one of the `.types` in [semanic.yml](https://github.com/mrlunchbox777/basic-setup/blob/main/.github/semantic.yml), followed by a `: `, e.g. `feature: My PR`

<details><summary>Issue</summary>What issue are you resolving with this PR? Please provide the number or link. _NOTE:_ If you don't have an issue for this work, please create one before creating this PR.</details>

__Response:__ #41

<details><summary>Description</summary>Please describe how this PR is addressing the issue and/or why it is being addressed this way.</details>

__Response:__ This PR fixes the bug by adding bash try/catches around possible failures, then logging and exiting with 0 in the catches

<details><summary>Steps to Reproduce and Test</summary>Please give us a step-by-step guide to reproduce the bug. A link to the steps in the issue is enough.</details>

__Response:__
1. Delete the shared-scripts dir
2. Open a new terminal that would run basic-setup.generalrc.sh as part of it's initialization
3. It should have failed to open, but now should let you know it's failing to finish and why (it will take longer while trying to find shared-scripts)

## Required Checkboxes

All of these checkboxes are required for PR's to be considered.

### PR Checks

- [ ] I answered all of the background questions
- [ ] I have added sensible labels to the associated issue and this PR
- [ ] I have added/updated tests for all added/modified code, and all tests are passing
- [ ] I have added documentation, as appropriate, including CHANGELOG and version updates as needed

### Code of Conduct

By submitting this PR, you agree to follow our [Code of Conduct](https://github.com/mrlunchbox777/basic-setup/tree/main/.github/CODE_OF_CONDUCT.md)

- [ ] I agree to follow this project's Code of Conduct
