### PR TITLE
bug: fixing an extra - in the feature template

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature.yaml
+++ b/.github/ISSUE_TEMPLATE/feature.yaml
@@ -34,7 +34,7 @@ body:
   - type: textarea
     id: what-should-happen
     attributes:
-      label: What-should happen?
+      label: What should happen?
       description: What feature are you requesting? Please include as much detail as possible.
       placeholder: Tell us, in detail, what you want added or changed!
     validations:


### PR DESCRIPTION
Thanks for contributing!

## Background

To pass the semanic-prs check, ensure you prefix your title with one of the `.types` in [semanic.yml](https://github.com/mrlunchbox777/basic-setup/blob/main/.github/semantic.yml), followed by a `: `, e.g. `feature: My PR`

<details><summary>Issue</summary>What issue are you resolving with this PR? Please provide the number or link. _NOTE:_ If you don't have an issue for this work, please create one before creating this PR.</details>

__Response:__ n/a

<details><summary>Description</summary>Please describe how this PR is addressing the issue and/or why it is being addressed this way.</details>

__Response:__ This PR fixes the bug by removing the extra - in the feature template.

<details><summary>Steps to Reproduce and Test</summary>Please give us a step-by-step guide to reproduce the bug. A link to the steps in the issue is enough.</details>

__Response:__
1. Start creating a feature issue using the web templates
2. `What-should happen` should now be `What should happen`

## Required Checkboxes

All of these checkboxes are required for PR's to be considered.

### PR Checks

- [x] I answered all of the background questions
- [x] I have added sensible labels to the associated issue and this PR
- [x] I have added/updated tests for all added/modified code, and all tests are passing
- [x] I have added documentation, as appropriate, including CHANGELOG and version updates as needed

### Code of Conduct

By submitting this PR, you agree to follow our [Code of Conduct](https://github.com/mrlunchbox777/basic-setup/tree/main/.github/CODE_OF_CONDUCT.md)

- [x] I agree to follow this project's Code of Conduct
